### PR TITLE
Add confirmation step for Excel user uploads

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -509,11 +509,17 @@ export const api = {
 			lastName,
 			role,
 		}),
-        uploadUsersExcel: (formData: FormData, role?: string, groupId?: number) =>
+        uploadUsersExcel: (
+                formData: FormData,
+                role?: string,
+                groupId?: number,
+                dryRun?: boolean
+        ) =>
                 axiosInstance.post("/users/upload-excel", formData, {
                         params: {
                                 ...(role && { role }),
                                 ...(groupId && { groupId }),
+                                ...(dryRun && { dryRun }),
                         },
                         headers: { "Content-Type": "multipart/form-data" },
                 }),


### PR DESCRIPTION
## Summary
- require confirmation before committing Excel user imports
- support preview uploads via new `dryRun` option on upload API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a318dd7f7c832482780549fe9046ea