### PR TITLE
Remove unused course unit and department fields

### DIFF
--- a/app/dashboard/admin/academic-groups/page.tsx
+++ b/app/dashboard/admin/academic-groups/page.tsx
@@ -148,12 +148,7 @@ export default function AcademicGroupsManagement() {
 				api.getAllCourses(1, 100),
 				api.getUsers(1, 100, undefined, "teacher"),
 			]);
-			setCourses(
-				coursesRes.data.items.map((course: any) => ({
-					...course,
-					units: course.units || 0, // Ensure units property exists
-				}))
-			);
+                        setCourses(coursesRes.data.items);
 			setProfessors(professorsRes.data.items);
 		} catch (err: any) {
 			toast.error("Error fetching courses and professors");

--- a/app/dashboard/admin/courses/page.tsx
+++ b/app/dashboard/admin/courses/page.tsx
@@ -27,12 +27,10 @@ import { useEffect, useState } from "react";
 import { useDebounce } from "@/hooks/useDebounce";
 
 interface Course {
-	id: number;
-	name: string;
-	code: string;
-	units: number;
-	department?: string;
-	groups: CourseGroup[];
+        id: number;
+        name: string;
+        code: string;
+        groups: CourseGroup[];
 }
 
 interface CourseGroup {
@@ -52,8 +50,6 @@ export default function CoursesManagement() {
         const [formData, setFormData] = useState({
                 name: "",
                 code: "",
-                units: "",
-                department: "",
         });
 	const [error, setError] = useState("");
 	const { isOpen, onOpen, onClose } = useDisclosure();
@@ -86,25 +82,16 @@ export default function CoursesManagement() {
         };
 
         const handleCreateCourse = async () => {
-                const units = Number(formData.units);
-                if (isNaN(units) || units <= 0) {
-                        setError("تعداد واحد معتبر نیست");
-                        return;
-                }
                 try {
                         await api.createCourse({
                                 name: formData.name,
                                 code: formData.code,
-                                units,
-                                department: formData.department || undefined,
                         });
                         onClose();
                         fetchCourses(page);
                         setFormData({
                                 name: "",
                                 code: "",
-                                units: "",
-                                department: "",
                         });
                         setError("");
                 } catch (err: any) {
@@ -237,23 +224,6 @@ export default function CoursesManagement() {
 										setFormData({ ...formData, code: e.target.value })
 									}
 								/>
-								<Input
-									label="تعداد واحد"
-									placeholder="مثال: 3"
-									type="number"
-									value={formData.units}
-									onChange={(e) =>
-										setFormData({ ...formData, units: e.target.value })
-									}
-								/>
-								<Input
-									label="گروه آموزشی"
-									placeholder="مثال: ریاضی"
-									value={formData.department}
-									onChange={(e) =>
-										setFormData({ ...formData, department: e.target.value })
-									}
-								/>
 							</ModalBody>
 							<ModalFooter>
 								<Button color="danger" variant="light" onPress={onClose}>
@@ -262,9 +232,7 @@ export default function CoursesManagement() {
 								<Button
 									color="primary"
 									onPress={handleCreateCourse}
-									isDisabled={
-										!formData.name || !formData.code || !formData.units
-									}>
+                                                                        isDisabled={!formData.name || !formData.code}>
 									افزودن درس
 								</Button>
 							</ModalFooter>

--- a/app/dashboard/admin/enrollments/page.tsx
+++ b/app/dashboard/admin/enrollments/page.tsx
@@ -25,20 +25,18 @@ import { useEffect, useState } from "react";
 interface Enrollment {
 	id: number;
 	student: { id: number; username: string } | null;
-	group: {
-		id: number;
-		groupNumber: number;
-		capacity: number;
-		currentEnrollment: number;
-		course: {
-			id: number;
-			name: string;
-			code: string;
-			units: number;
-			department: string;
-		} | null;
-		professor: { id: number; username: string } | null;
-	} | null;
+        group: {
+                id: number;
+                groupNumber: number;
+                capacity: number;
+                currentEnrollment: number;
+                course: {
+                        id: number;
+                        name: string;
+                        code: string;
+                } | null;
+                professor: { id: number; username: string } | null;
+        } | null;
 	score?: number;
 	createdAt: string;
 	isActive: boolean;

--- a/app/dashboard/admin/groups/page.tsx
+++ b/app/dashboard/admin/groups/page.tsx
@@ -40,11 +40,10 @@ interface Group {
 }
 
 interface Course {
-	id: number;
-	name: string;
-	code: string;
-	units: number;
-	professor: { name: string };
+        id: number;
+        name: string;
+        code: string;
+        professor: { name: string };
 }
 
 export default function GroupsManagement() {

--- a/app/dashboard/student/page.tsx
+++ b/app/dashboard/student/page.tsx
@@ -50,13 +50,11 @@ interface Enrollment {
 }
 
 interface CourseWithGroups {
-	id: number;
-	name: string;
-	code: string;
-	units: number;
-	department: string;
-	subject: string;
-	groups: Array<{
+        id: number;
+        name: string;
+        code: string;
+        subject: string;
+        groups: Array<{
 		id: number;
 		groupNumber: number;
 		currentEnrollment: number;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -376,12 +376,10 @@ export const api = {
 		}),
 	createEnrollment: (studentId: number, groupId: number) =>
 		axiosInstance.post("/enrollments", { studentId, groupId }),
-	createCourse: (data: {
-		name: string;
-		code: string;
-		units: number;
-		department?: string;
-	}) => axiosInstance.post<Course>("/courses", data),
+        createCourse: (data: {
+                name: string;
+                code: string;
+        }) => axiosInstance.post<Course>("/courses", data),
 	deleteCourse: (id: number) => axiosInstance.delete(`/courses/${id}`),
 	getCourseById: (id: number) => axiosInstance.get(`/courses/${id}`),
 	getStudentCourses: (studentId: number) =>

--- a/lib/types/common.ts
+++ b/lib/types/common.ts
@@ -33,11 +33,9 @@ export interface Group {
 }
 
 export interface Course {
-	id: number;
-	name: string; // e.g., "Mathematics"
-	code: string; // e.g., "MATH101"
-	units: number;
-	department?: string;
+        id: number;
+        name: string; // e.g., "Mathematics"
+        code: string; // e.g., "MATH101"
 }
 
 export interface CourseAssignment {
@@ -63,13 +61,12 @@ export interface Enrollment {
 	};
 	group: {
 		id: number;
-		groupNumber: number;
-		course: {
-			id: number;
-			name: string;
-			code: string;
-			units: number;
-		};
+                groupNumber: number;
+                course: {
+                        id: number;
+                        name: string;
+                        code: string;
+                };
 		professor: {
 			id: number;
 			username: string;


### PR DESCRIPTION
## Summary
- drop course `units` and `department` fields from shared types and API calls
- simplify course creation form to only request code and name
- remove unit and department references from related admin/student pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a42ff05d8083249ed9c22b6cc157d4