### PR TITLE
feat: assign users to groups during creation

### DIFF
--- a/components/UsersManagement/UploadExcelModal.tsx
+++ b/components/UsersManagement/UploadExcelModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { api } from "@/lib/api";
+import { api, groupsApi } from "@/lib/api";
 import {
         Button,
         Card,
@@ -29,9 +29,11 @@ import {
         ReactElement,
         ReactNode,
         ReactPortal,
+        useEffect,
         useState,
 } from "react";
 import { toast } from "sonner";
+import { Group } from "@/lib/types/common";
 
 interface RegisteredUser {
 	id: number;
@@ -66,15 +68,24 @@ export function UploadExcelModal({
         const [duplicateUsers, setDuplicateUsers] = useState<DuplicateUser[]>([]);
         const [uploadErrors, setUploadErrors] = useState<string[]>([]);
         const [groupId, setGroupId] = useState("");
+        const [groups, setGroups] = useState<Group[]>([]);
         const [role, setRole] = useState("student");
         const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+        useEffect(() => {
+                if (isOpen) {
+                        groupsApi.getAllGroups(1, 100).then((res) => {
+                                setGroups(res.data.items || []);
+                        });
+                }
+        }, [isOpen]);
 
         const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
                 const file = e.target.files?.[0];
                 if (!file) return;
 
                 if (!groupId) {
-                        toast.error("لطفا شماره گروه را وارد کنید");
+                        toast.error("لطفا گروه را انتخاب کنید");
                         return;
                 }
 
@@ -116,7 +127,7 @@ export function UploadExcelModal({
                 }
 
                 if (!groupId) {
-                        toast.error("لطفا شماره گروه را وارد کنید");
+                        toast.error("لطفا گروه را انتخاب کنید");
                         return;
                 }
 
@@ -188,13 +199,21 @@ export function UploadExcelModal({
 						</ModalHeader>
 						<ModalBody>
 							<div className="space-y-4">
-                                                                <Input
-                                                                        label="شماره گروه"
-                                                                        value={groupId}
+                                                                <Select
+                                                                        label="گروه"
+                                                                        placeholder="گروه را انتخاب کنید"
+                                                                        selectedKeys={[groupId]}
                                                                         onChange={(e) => setGroupId(e.target.value)}
-                                                                        variant="bordered"
                                                                         className="text-right"
-                                                                />
+                                                                        variant="bordered">
+                                                                        {groups.map((g) => (
+                                                                                <SelectItem
+                                                                                        key={g.id}
+                                                                                        value={g.id.toString()}>
+                                                                                        {g.name}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </Select>
                                                                 <Select
                                                                         label="نقش کاربران"
                                                                         selectedKeys={[role]}

--- a/components/UsersManagement/UserModal.tsx
+++ b/components/UsersManagement/UserModal.tsx
@@ -12,18 +12,21 @@ import {
 	SelectItem,
 } from "@nextui-org/react";
 import { GraduationCap, School, ShieldCheck } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { groupsApi } from "@/lib/api";
+import { Group } from "@/lib/types/common";
 
 interface UserModalProps {
 	isOpen: boolean;
 	onClose: () => void;
-	onSubmit: (
-		username: string,
-		password: string,
-		firstName: string,
-		lastName: string,
-		role: string
-	) => void;
+        onSubmit: (
+                username: string,
+                password: string,
+                firstName: string,
+                lastName: string,
+                role: string,
+                groupId: number
+        ) => void;
 }
 
 const roleOptions = [
@@ -48,21 +51,40 @@ const roleOptions = [
 ];
 
 export function UserModal({ isOpen, onClose, onSubmit }: UserModalProps) {
-	const [username, setUsername] = useState("");
-	const [password, setPassword] = useState("");
-	const [firstName, setFirstName] = useState("");
-	const [lastName, setLastName] = useState("");
-	const [role, setRole] = useState("student");
+        const [username, setUsername] = useState("");
+        const [password, setPassword] = useState("");
+        const [firstName, setFirstName] = useState("");
+        const [lastName, setLastName] = useState("");
+        const [role, setRole] = useState("student");
+        const [groupId, setGroupId] = useState("");
+        const [groups, setGroups] = useState<Group[]>([]);
 
-	const handleSubmit = () => {
-		if (!username || !password || !firstName || !lastName || !role) return;
-		onSubmit(username, password, firstName, lastName, role);
-		setUsername("");
-		setPassword("");
-		setFirstName("");
-		setLastName("");
-		setRole("student");
-	};
+        useEffect(() => {
+                if (isOpen) {
+                        groupsApi.getAllGroups(1, 100).then((res) => {
+                                setGroups(res.data.items || []);
+                        });
+                }
+        }, [isOpen]);
+
+        const handleSubmit = () => {
+                if (!username || !password || !firstName || !lastName || !role || !groupId)
+                        return;
+                onSubmit(
+                        username,
+                        password,
+                        firstName,
+                        lastName,
+                        role,
+                        Number(groupId)
+                );
+                setUsername("");
+                setPassword("");
+                setFirstName("");
+                setLastName("");
+                setRole("student");
+                setGroupId("");
+        };
 
 	return (
 		<Modal
@@ -130,30 +152,49 @@ export function UserModal({ isOpen, onClose, onSubmit }: UserModalProps) {
 										input: "text-right",
 									}}
 								/>
-								<Select
-									label="نقش کاربر"
-									placeholder="نقش کاربر را انتخاب کنید"
-									selectedKeys={[role]}
-									onChange={(e) => setRole(e.target.value)}
-									variant="bordered"
-									classNames={{
-										label: "text-right",
-										value: "text-right",
-										trigger: "h-12",
-									}}>
-									{roleOptions.map((option) => (
-										<SelectItem
-											key={option.value}
-											value={option.value}
-											startContent={
-												<option.icon className={`w-4 h-4 ${option.color}`} />
-											}>
-											{option.label}
-										</SelectItem>
-									))}
-								</Select>
-							</div>
-						</ModalBody>
+                                                                <Select
+                                                                        label="نقش کاربر"
+                                                                        placeholder="نقش کاربر را انتخاب کنید"
+                                                                        selectedKeys={[role]}
+                                                                        onChange={(e) => setRole(e.target.value)}
+                                                                        variant="bordered"
+                                                                        classNames={{
+                                                                                label: "text-right",
+                                                                                value: "text-right",
+                                                                                trigger: "h-12",
+                                                                        }}>
+                                                                        {roleOptions.map((option) => (
+                                                                                <SelectItem
+                                                                                        key={option.value}
+                                                                                        value={option.value}
+                                                                                        startContent={
+                                                                                                <option.icon
+                                                                                                        className={`w-4 h-4 ${option.color}`}
+                                                                                                />
+                                                                                        }>
+                                                                                        {option.label}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </Select>
+                                                                <Select
+                                                                        label="گروه"
+                                                                        placeholder="گروه را انتخاب کنید"
+                                                                        selectedKeys={[groupId]}
+                                                                        onChange={(e) => setGroupId(e.target.value)}
+                                                                        variant="bordered"
+                                                                        classNames={{
+                                                                                label: "text-right",
+                                                                                value: "text-right",
+                                                                                trigger: "h-12",
+                                                                        }}>
+                                                                        {groups.map((g) => (
+                                                                                <SelectItem key={g.id} value={g.id.toString()}>
+                                                                                        {g.name}
+                                                                                </SelectItem>
+                                                                        ))}
+                                                                </Select>
+                                                        </div>
+                                                </ModalBody>
 						<ModalFooter>
 							<Button
 								color="danger"

--- a/components/UsersManagement/index.tsx
+++ b/components/UsersManagement/index.tsx
@@ -94,22 +94,30 @@ export function UsersManagement({
 		}
 	}, [selectedUser]);
 
-	const handleCreateUser = async (
-		username: string,
-		password: string,
-		firstName: string,
-		lastName: string,
-		role: string
-	) => {
-		try {
-			await api.createUserManual(username, password, firstName, lastName, role);
-			onUserChange?.(); // Call the callback directly
-			onClose();
-			toast.success("کاربر با موفقیت ایجاد شد");
-		} catch (err: any) {
-			setError(getPersianErrorMessage(err.message));
-		}
-	};
+        const handleCreateUser = async (
+                username: string,
+                password: string,
+                firstName: string,
+                lastName: string,
+                role: string,
+                groupId: number
+        ) => {
+                try {
+                        await api.createUserManual(
+                                username,
+                                password,
+                                firstName,
+                                lastName,
+                                role,
+                                groupId
+                        );
+                        onUserChange?.(); // Call the callback directly
+                        onClose();
+                        toast.success("کاربر با موفقیت ایجاد شد");
+                } catch (err: any) {
+                        setError(getPersianErrorMessage(err.message));
+                }
+        };
 
 	const handleEditUser = (user: User) => {
 		setSelectedUser(user);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -494,20 +494,22 @@ export const api = {
 	updateUserRole: (id: number, role: string) =>
 		axiosInstance.patch(`/users/${id}/role`, { role }),
 	deleteUser: (id: number) => axiosInstance.delete(`/users/${id}`),
-	createUserManual: (
-		username: string,
-		password: string,
-		firstName: string,
-		lastName: string,
-		role: string
-	) =>
-		axiosInstance.post("/users/manual", {
-			username,
-			password,
-			firstName,
-			lastName,
-			role,
-		}),
+        createUserManual: (
+                username: string,
+                password: string,
+                firstName: string,
+                lastName: string,
+                role: string,
+                groupId?: number
+        ) =>
+                axiosInstance.post("/users/manual", {
+                        username,
+                        password,
+                        firstName,
+                        lastName,
+                        role,
+                        ...(groupId && { groupId }),
+                }),
         uploadUsersExcel: (
                 formData: FormData,
                 role?: string,
@@ -524,14 +526,15 @@ export const api = {
                 }),
 	updateUser: (
 		id: number,
-		data: {
-			username?: string;
-			password?: string;
-			firstName?: string;
-			lastName?: string;
-			role?: string;
-		}
-	) => axiosInstance.patch(`/users/${id}`, data),
+                data: {
+                        username?: string;
+                        password?: string;
+                        firstName?: string;
+                        lastName?: string;
+                        role?: string;
+                        groupId?: number;
+                }
+        ) => axiosInstance.patch(`/users/${id}`, data),
 	deleteMultipleUsers: (userIds: number[]) =>
 		axiosInstance.post("/users/delete-multiple", { userIds }),
 	deleteAllStudents: () => axiosInstance.get("/users/delete-students"),


### PR DESCRIPTION
## Summary
- allow selecting a group when manually creating users
- support group choice when importing users via Excel
- extend API helpers to pass groupId for user creation and updates

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a98ebcb4d48324a389ed71777a4ee1