### PR TITLE
feat: add group management and selection

### DIFF
--- a/app/dashboard/admin/group-management/page.tsx
+++ b/app/dashboard/admin/group-management/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { groupsApi } from "@/lib/api";
+import { Group, PaginatedResponse } from "@/lib/types/common";
+import {
+  Button,
+  Card,
+  CardBody,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Pagination,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  useDisclosure,
+} from "@nextui-org/react";
+import { AlertCircle, Plus, Search } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export default function GroupManagement() {
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [search, setSearch] = useState("");
+  const [error, setError] = useState("");
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [formName, setFormName] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetchGroups(page, search);
+  }, [page, search]);
+
+  const fetchGroups = async (currentPage: number, query: string) => {
+    try {
+      const res = await groupsApi.getAllGroups(currentPage, 10, query);
+      const data = res.data as PaginatedResponse<Group>;
+      setGroups(data.items);
+      setTotalPages(data.meta.totalPages);
+    } catch (err: any) {
+      setError(err.message);
+      setGroups([]);
+    }
+  };
+
+  const openCreate = () => {
+    setEditingId(null);
+    setFormName("");
+    onOpen();
+  };
+
+  const openEdit = (g: Group) => {
+    setEditingId(g.id);
+    setFormName(g.name);
+    onOpen();
+  };
+
+  const handleSave = async () => {
+    try {
+      if (editingId) {
+        await groupsApi.updateGroup(editingId, { name: formName });
+      } else {
+        await groupsApi.createGroup({ name: formName });
+      }
+      onClose();
+      fetchGroups(page, search);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("آیا از حذف این گروه اطمینان دارید؟")) return;
+    try {
+      await groupsApi.deleteGroup(id);
+      fetchGroups(page, search);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-2xl font-bold">مدیریت گروه‌ها</h2>
+          <p className="text-neutral-600 dark:text-neutral-400">
+            {groups.length} گروه ثبت شده
+          </p>
+        </div>
+        <Button
+          color="primary"
+          startContent={<Plus className="w-4 h-4" />}
+          onPress={openCreate}
+        >
+          افزودن گروه
+        </Button>
+      </div>
+      <Card className="border border-neutral-200/50 dark:border-neutral-800/50">
+        <CardBody className="p-0">
+          <div className="p-4 border-b border-neutral-200/50 dark:border-neutral-800/50">
+            <Input
+              placeholder="جستجو در گروه‌ها..."
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              startContent={<Search className="w-4 h-4 text-neutral-500" />}
+              className="w-full sm:w-72"
+            />
+          </div>
+          <Table aria-label="لیست گروه‌ها">
+            <TableHeader>
+              <TableColumn>نام گروه</TableColumn>
+              <TableColumn>عملیات</TableColumn>
+            </TableHeader>
+            <TableBody emptyContent="گروهی یافت نشد">
+              {groups.map((g) => (
+                <TableRow key={g.id}>
+                  <TableCell>{g.name}</TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        color="primary"
+                        variant="flat"
+                        onClick={() => openEdit(g)}
+                      >
+                        ویرایش
+                      </Button>
+                      <Button
+                        size="sm"
+                        color="danger"
+                        variant="flat"
+                        onClick={() => handleDelete(g.id)}
+                      >
+                        حذف
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardBody>
+      </Card>
+      <div className="flex justify-center">
+        <Pagination
+          total={totalPages}
+          initialPage={1}
+          page={page}
+          onChange={(p) => setPage(p)}
+        />
+      </div>
+      {error && (
+        <div className="fixed bottom-6 right-6 bg-danger-50 dark:bg-danger-900/30 text-danger-600 dark:text-danger-400 p-4 rounded-xl shadow-lg flex items-center gap-3">
+          <AlertCircle className="w-5 h-5" />
+          <p>{error}</p>
+        </div>
+      )}
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>
+                {editingId ? "ویرایش گروه" : "افزودن گروه جدید"}
+              </ModalHeader>
+              <ModalBody className="gap-4">
+                <Input
+                  label="نام گروه"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                />
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" variant="light" onPress={onClose}>
+                  انصراف
+                </Button>
+                <Button
+                  color="primary"
+                  onPress={handleSave}
+                  isDisabled={!formName.trim()}
+                >
+                  ذخیره
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -19,6 +19,7 @@ import CourseGroupsManagement from "./course-groups/page";
 import CoursesManagement from "./courses/page";
 import EnrollmentsManagement from "./enrollments/page";
 import AdminScoreManagement from "./scores/page";
+import GroupManagement from "./group-management/page";
 
 export default function AdminDashboard() {
 	const { token } = useAuthStore();
@@ -129,6 +130,17 @@ export default function AdminDashboard() {
                                                                         </div>
                                                                 }>
                                                                 <CoursesManagement />
+                                                        </Tab>
+
+                                                        <Tab
+                                                                key="groups"
+                                                                title={
+                                                                        <div className="flex items-center gap-2">
+                                                                                <Users className="w-4 h-4" />
+                                                                                <span>گروه‌ها</span>
+                                                                        </div>
+                                                                }>
+                                                                <GroupManagement />
                                                         </Tab>
 
                                                         <Tab

--- a/app/dashboard/teacher/components/ScoreUploadModal.tsx
+++ b/app/dashboard/teacher/components/ScoreUploadModal.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@nextui-org/react";
+import { Upload } from "lucide-react";
+import { api } from "@/lib/api";
+import { toast } from "sonner";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  groupId: number | null;
+}
+
+export function ScoreUploadModal({ isOpen, onClose, groupId }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0] || null;
+    setFile(selected);
+  };
+
+  const handleUpload = async () => {
+    if (!groupId || !file) return;
+    const formData = new FormData();
+    formData.append("file", file);
+    try {
+      setIsUploading(true);
+      await api.uploadGroupScoresExcel(groupId, formData);
+      toast.success("نمرات با موفقیت بارگذاری شد");
+      setFile(null);
+      onClose();
+    } catch (err: any) {
+      toast.error(err.message || "خطا در بارگذاری فایل");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader className="flex flex-col gap-1">
+              آپلود نمرات از فایل اکسل
+            </ModalHeader>
+            <ModalBody>
+              <Input
+                type="file"
+                accept=".xlsx,.xls"
+                onChange={handleFileChange}
+                startContent={<Upload className="w-4 h-4 text-primary" />}
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button color="danger" variant="light" onPress={onClose}>
+                انصراف
+              </Button>
+              <Button
+                color="primary"
+                onPress={handleUpload}
+                isDisabled={!file || isUploading}
+                isLoading={isUploading}
+              >
+                آپلود
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}
+

--- a/app/dashboard/teacher/page.tsx
+++ b/app/dashboard/teacher/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ScoreSubmissionModal } from "./components/ScoreSubmissionModal";
+import { ScoreUploadModal } from "./components/ScoreUploadModal";
 
 interface Group {
   id: number;
@@ -40,6 +41,8 @@ export default function TeacherDashboard() {
     students: Student[];
   } | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const [uploadGroupId, setUploadGroupId] = useState<number | null>(null);
 
   useEffect(() => {
     if (!token) {
@@ -88,6 +91,11 @@ export default function TeacherDashboard() {
       setError(err.message);
       toast.error("خطا در دریافت لیست دانشجویان");
     }
+  };
+
+  const openUploadModal = (group: Group) => {
+    setUploadGroupId(group.id);
+    setIsUploadModalOpen(true);
   };
 
   const handleSubmitScores = async (scores: Record<number, number>) => {
@@ -141,15 +149,25 @@ export default function TeacherDashboard() {
                       className="flex items-center justify-between p-2 rounded-lg hover:bg-neutral-100/50 dark:hover:bg-neutral-800/50"
                     >
                       <span>گروه {group.groupNumber}</span>
-                      <Button
-                        size="sm"
-                        color="primary"
-                        variant="flat"
-                        endContent={<ChevronRight className="w-4 h-4" />}
-                        onClick={() => openScoreModal(course, group)}
-                      >
-                        مدیریت نمرات
-                      </Button>
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          color="primary"
+                          variant="flat"
+                          endContent={<ChevronRight className="w-4 h-4" />}
+                          onClick={() => openScoreModal(course, group)}
+                        >
+                          مدیریت نمرات
+                        </Button>
+                        <Button
+                          size="sm"
+                          color="secondary"
+                          variant="flat"
+                          onClick={() => openUploadModal(group)}
+                        >
+                          آپلود اکسل
+                        </Button>
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -177,6 +195,11 @@ export default function TeacherDashboard() {
                 }
               : null}
           onSubmitScores={handleSubmitScores}
+        />
+        <ScoreUploadModal
+          isOpen={isUploadModalOpen}
+          onClose={() => setIsUploadModalOpen(false)}
+          groupId={uploadGroupId}
         />
       </div>
     </div>

--- a/components/GroupSelect.tsx
+++ b/components/GroupSelect.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { groupsApi } from "@/lib/api";
+import { Group } from "@/lib/types/common";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Select,
+  SelectItem,
+} from "@nextui-org/react";
+import { Plus } from "lucide-react";
+
+interface GroupSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  placeholder?: string;
+}
+
+export function GroupSelect({ value, onChange, label, placeholder }: GroupSelectProps) {
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newGroupName, setNewGroupName] = useState("");
+
+  const loadGroups = async () => {
+    const res = await groupsApi.getAllGroups(1, 100);
+    setGroups(res.data.items || []);
+  };
+
+  useEffect(() => {
+    loadGroups();
+  }, []);
+
+  const handleAddGroup = async () => {
+    if (!newGroupName.trim()) return;
+    await groupsApi.createGroup({ name: newGroupName.trim() });
+    setNewGroupName("");
+    setIsModalOpen(false);
+    await loadGroups();
+  };
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <Select
+          label={label || "گروه"}
+          placeholder={placeholder || "گروه را انتخاب کنید"}
+          selectedKeys={value ? [value] : []}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1"
+          variant="bordered"
+        >
+          {groups.map((g) => (
+            <SelectItem key={g.id} value={g.id.toString()}>
+              {g.name}
+            </SelectItem>
+          ))}
+        </Select>
+        <Button
+          isIconOnly
+          color="primary"
+          variant="flat"
+          onPress={() => setIsModalOpen(true)}
+        >
+          <Plus className="w-4 h-4" />
+        </Button>
+      </div>
+
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>افزودن گروه جدید</ModalHeader>
+              <ModalBody>
+                <Input
+                  autoFocus
+                  label="نام گروه"
+                  value={newGroupName}
+                  onChange={(e) => setNewGroupName(e.target.value)}
+                />
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" variant="light" onPress={onClose}>
+                  انصراف
+                </Button>
+                <Button color="primary" onPress={handleAddGroup} isDisabled={!newGroupName.trim()}>
+                  افزودن
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+export default GroupSelect;

--- a/components/UsersManagement/UploadExcelModal.tsx
+++ b/components/UsersManagement/UploadExcelModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { api, groupsApi } from "@/lib/api";
+import { api } from "@/lib/api";
 import {
         Button,
         Card,
@@ -29,11 +29,10 @@ import {
         ReactElement,
         ReactNode,
         ReactPortal,
-        useEffect,
         useState,
 } from "react";
 import { toast } from "sonner";
-import { Group } from "@/lib/types/common";
+import { GroupSelect } from "@/components/GroupSelect";
 
 interface RegisteredUser {
 	id: number;
@@ -68,17 +67,9 @@ export function UploadExcelModal({
         const [duplicateUsers, setDuplicateUsers] = useState<DuplicateUser[]>([]);
         const [uploadErrors, setUploadErrors] = useState<string[]>([]);
         const [groupId, setGroupId] = useState("");
-        const [groups, setGroups] = useState<Group[]>([]);
         const [role, setRole] = useState("student");
         const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
-        useEffect(() => {
-                if (isOpen) {
-                        groupsApi.getAllGroups(1, 100).then((res) => {
-                                setGroups(res.data.items || []);
-                        });
-                }
-        }, [isOpen]);
 
         const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
                 const file = e.target.files?.[0];
@@ -199,21 +190,7 @@ export function UploadExcelModal({
 						</ModalHeader>
 						<ModalBody>
 							<div className="space-y-4">
-                                                                <Select
-                                                                        label="گروه"
-                                                                        placeholder="گروه را انتخاب کنید"
-                                                                        selectedKeys={[groupId]}
-                                                                        onChange={(e) => setGroupId(e.target.value)}
-                                                                        className="text-right"
-                                                                        variant="bordered">
-                                                                        {groups.map((g) => (
-                                                                                <SelectItem
-                                                                                        key={g.id}
-                                                                                        value={g.id.toString()}>
-                                                                                        {g.name}
-                                                                                </SelectItem>
-                                                                        ))}
-                                                                </Select>
+                                                                <GroupSelect value={groupId} onChange={setGroupId} />
                                                                 <Select
                                                                         label="نقش کاربران"
                                                                         selectedKeys={[role]}

--- a/components/UsersManagement/UserModal.tsx
+++ b/components/UsersManagement/UserModal.tsx
@@ -12,9 +12,8 @@ import {
 	SelectItem,
 } from "@nextui-org/react";
 import { GraduationCap, School, ShieldCheck } from "lucide-react";
-import { useEffect, useState } from "react";
-import { groupsApi } from "@/lib/api";
-import { Group } from "@/lib/types/common";
+import { useState } from "react";
+import { GroupSelect } from "@/components/GroupSelect";
 
 interface UserModalProps {
 	isOpen: boolean;
@@ -57,15 +56,6 @@ export function UserModal({ isOpen, onClose, onSubmit }: UserModalProps) {
         const [lastName, setLastName] = useState("");
         const [role, setRole] = useState("student");
         const [groupId, setGroupId] = useState("");
-        const [groups, setGroups] = useState<Group[]>([]);
-
-        useEffect(() => {
-                if (isOpen) {
-                        groupsApi.getAllGroups(1, 100).then((res) => {
-                                setGroups(res.data.items || []);
-                        });
-                }
-        }, [isOpen]);
 
         const handleSubmit = () => {
                 if (!username || !password || !firstName || !lastName || !role || !groupId)
@@ -176,23 +166,7 @@ export function UserModal({ isOpen, onClose, onSubmit }: UserModalProps) {
                                                                                 </SelectItem>
                                                                         ))}
                                                                 </Select>
-                                                                <Select
-                                                                        label="گروه"
-                                                                        placeholder="گروه را انتخاب کنید"
-                                                                        selectedKeys={[groupId]}
-                                                                        onChange={(e) => setGroupId(e.target.value)}
-                                                                        variant="bordered"
-                                                                        classNames={{
-                                                                                label: "text-right",
-                                                                                value: "text-right",
-                                                                                trigger: "h-12",
-                                                                        }}>
-                                                                        {groups.map((g) => (
-                                                                                <SelectItem key={g.id} value={g.id.toString()}>
-                                                                                        {g.name}
-                                                                                </SelectItem>
-                                                                        ))}
-                                                                </Select>
+                                                                <GroupSelect value={groupId} onChange={setGroupId} />
                                                         </div>
                                                 </ModalBody>
 						<ModalFooter>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -178,10 +178,13 @@ export const groupsApi = {
 			params: { page, limit, search },
 		}),
 
-	createGroup: (data: { name: string }) =>
-		axiosInstance.post<Group>("/groups", data),
+        createGroup: (data: { name: string }) =>
+                axiosInstance.post<Group>("/groups", data),
 
-	deleteGroup: (id: number) => axiosInstance.delete(`/groups/${id}`),
+        updateGroup: (id: number, data: { name: string }) =>
+                axiosInstance.patch<Group>(`/groups/${id}`, data),
+
+        deleteGroup: (id: number) => axiosInstance.delete(`/groups/${id}`),
 
 	removeStudentsFromGroup: (groupId: number, studentIds: number[]) =>
 		axiosInstance.delete(`/groups/${groupId}/students`, {
@@ -615,10 +618,17 @@ export const api = {
 		),
 	updateScore: (enrollmentId: number, score: number) =>
 		axiosInstance.put(`/enrollments/${enrollmentId}/score`, { score }),
-	submitGroupScores: (
-		groupId: number,
-		scores: Array<{ studentId: number; score: number }>
-	) => axiosInstance.post(`/groups/${groupId}/scores`, { scores }),
+        submitGroupScores: (
+                groupId: number,
+                scores: Array<{ studentId: number; score: number }>
+        ) => axiosInstance.post(`/groups/${groupId}/scores`, { scores }),
+        uploadGroupScoresExcel: (
+                groupId: number,
+                formData: FormData,
+        ) =>
+                axiosInstance.post(`/groups/${groupId}/scores/upload-excel`, formData, {
+                        headers: { "Content-Type": "multipart/form-data" },
+                }),
 };
 
 // Export the axios instance if needed elsewhere


### PR DESCRIPTION
## Summary
- add reusable `GroupSelect` for choosing or creating groups
- use `GroupSelect` in user creation and Excel upload modals
- introduce admin group management tab with full CRUD
- expose `updateGroup` helper in API client

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint? prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68addbf3694883248af461901cb66adb