### PR TITLE
fix: guard pagination metadata

### DIFF
--- a/app/dashboard/admin/courses/page.tsx
+++ b/app/dashboard/admin/courses/page.tsx
@@ -65,8 +65,8 @@ export default function CoursesManagement() {
                         const response = await api.getAllCourses(currentPage, 10, query);
                         const paginatedData = response.data as PaginatedResponse;
 
-			setCourses(paginatedData.items);
-			setTotalPages(paginatedData.meta.totalPages);
+                        setCourses(paginatedData.items);
+                        setTotalPages(paginatedData?.meta?.totalPages ?? 1);
 		} catch (err: any) {
 			console.error("Error fetching courses:", err);
 			setError(err.message);

--- a/app/dashboard/admin/enrollments/page.tsx
+++ b/app/dashboard/admin/enrollments/page.tsx
@@ -66,8 +66,8 @@ export default function EnrollmentsManagement() {
 			);
 			const paginatedData = response.data as PaginatedResponse;
 
-			setEnrollments(paginatedData.items);
-			setTotalPages(paginatedData.meta.totalPages);
+                        setEnrollments(paginatedData.items);
+                        setTotalPages(paginatedData?.meta?.totalPages ?? 1);
 		} catch (err: any) {
 			setError(err.message);
 			setEnrollments([]);

--- a/app/dashboard/admin/group-management/page.tsx
+++ b/app/dashboard/admin/group-management/page.tsx
@@ -43,7 +43,7 @@ export default function GroupManagement() {
       const res = await groupsApi.getAllGroups(currentPage, 10, query);
       const data = res.data as PaginatedResponse<Group>;
       setGroups(data.items);
-      setTotalPages(data.meta.totalPages);
+      setTotalPages(data?.meta?.totalPages ?? 1);
     } catch (err: any) {
       setError(err.message);
       setGroups([]);

--- a/app/dashboard/admin/groups/page.tsx
+++ b/app/dashboard/admin/groups/page.tsx
@@ -71,8 +71,8 @@ export default function GroupsManagement() {
 				10,
 				searchQuery
 			);
-			setGroups(response.data.items);
-			setTotalPages(response.data.meta.totalPages);
+                        setGroups(response.data.items);
+                        setTotalPages(response.data?.meta?.totalPages ?? 1);
 		} catch (err: any) {
 			console.error("Error fetching groups:", err);
 			setError(err.message);

--- a/app/dashboard/admin/scores/page.tsx
+++ b/app/dashboard/admin/scores/page.tsx
@@ -65,8 +65,8 @@ export default function ScoresManagement() {
 			const response = await api.getAllEnrollments(currentPage, 10, query);
 			const paginatedData = response.data as PaginatedResponse;
 
-			setEnrollments(paginatedData.items);
-			setTotalPages(paginatedData.meta.totalPages);
+                        setEnrollments(paginatedData.items);
+                        setTotalPages(paginatedData?.meta?.totalPages ?? 1);
 		} catch (err: any) {
 			console.error("Error fetching enrollments:", err);
 			setError(err.message);

--- a/app/dashboard/admin/users/page.tsx
+++ b/app/dashboard/admin/users/page.tsx
@@ -54,8 +54,8 @@ export default function UserManagement() {
 			const response = await api.getUsers(currentPage, 10, query);
 			const paginatedData = response.data as PaginatedResponse;
 
-			setUsers(paginatedData.items);
-			setTotalPages(paginatedData.meta.totalPages);
+                        setUsers(paginatedData.items);
+                        setTotalPages(paginatedData?.meta?.totalPages ?? 1);
 		} catch (err: any) {
 			console.error("Error fetching users:", err);
 			setError(err.message);

--- a/components/TicketSystem/TicketList.tsx
+++ b/components/TicketSystem/TicketList.tsx
@@ -46,9 +46,9 @@ export function TicketList({
 	const fetchTickets = async (currentPage: number) => {
 		try {
 			const response = await api.getAllTickets(currentPage, 10);
-			const paginatedData = response.data as PaginatedResponse;
-			setTickets(paginatedData.items);
-			setTotalPages(paginatedData.meta.totalPages);
+                        const paginatedData = response.data as PaginatedResponse;
+                        setTickets(paginatedData.items);
+                        setTotalPages(paginatedData?.meta?.totalPages ?? 1);
 			setIsLoading(false);
 		} catch (err: any) {
 			setError(err.message);

--- a/hooks/useUsers.ts
+++ b/hooks/useUsers.ts
@@ -78,8 +78,8 @@ export const useUsers = ({
 
                                 if (response.data && Array.isArray(response.data.items)) {
                                         setUsers(response.data.items);
-                                        setTotalPages(response.data.meta.totalPages || 1);
-                                        setTotalItems(response.data.meta.totalItems || 0);
+                                        setTotalPages(response.data?.meta?.totalPages ?? 1);
+                                        setTotalItems(response.data?.meta?.totalItems ?? 0);
                                 }
 			} catch (err) {
 				if ((err as Error).name !== "AbortError") {


### PR DESCRIPTION
## Summary
- prevent `totalPages` runtime errors by defaulting to page 1 when pagination metadata is missing
- apply optional chaining across user hooks, ticket list, and admin pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive ESLint setup prompt)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0b4595da483249b066121060a647e