### PR TITLE
Fix authentication hydration and group pagination issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/dashboard/admin/academic-groups/page.tsx
+++ b/app/dashboard/admin/academic-groups/page.tsx
@@ -133,14 +133,14 @@ export default function AcademicGroupsManagement() {
 		fetchCoursesAndProfessors();
 	}, []);
 
-	const fetchGroups = async () => {
-		try {
-			const { data } = await groupsApi.getAllGroups();
-			setGroups(data.items);
-		} catch (err: any) {
-			toast.error("Error fetching groups");
-		}
-	};
+        const fetchGroups = async () => {
+                try {
+                        const { data } = await groupsApi.getAllGroups();
+                        setGroups(data?.items ?? []);
+                } catch (err: any) {
+                        toast.error("Error fetching groups");
+                }
+        };
 
 	const fetchCoursesAndProfessors = async () => {
 		try {

--- a/app/dashboard/admin/group-management/page.tsx
+++ b/app/dashboard/admin/group-management/page.tsx
@@ -22,7 +22,7 @@ import {
   useDisclosure,
 } from "@nextui-org/react";
 import { AlertCircle, Plus, Search } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export default function GroupManagement() {
   const [groups, setGroups] = useState<Group[]>([]);
@@ -34,21 +34,25 @@ export default function GroupManagement() {
   const [formName, setFormName] = useState("");
   const [editingId, setEditingId] = useState<number | null>(null);
 
+  const fetchGroups = useCallback(
+    async (currentPage: number, query: string) => {
+      try {
+        const { data } = await groupsApi.getAllGroups(currentPage, 10, query);
+        const items = data?.items ?? [];
+        setGroups(items);
+        const fallbackTotalPages = items.length > 0 ? Math.max(1, Math.ceil(items.length / 10)) : 1;
+        setTotalPages(data?.meta?.totalPages ?? fallbackTotalPages);
+      } catch (err: any) {
+        setError(err.message);
+        setGroups([]);
+      }
+    },
+    []
+  );
+
   useEffect(() => {
     fetchGroups(page, search);
-  }, [page, search]);
-
-  const fetchGroups = async (currentPage: number, query: string) => {
-    try {
-      const res = await groupsApi.getAllGroups(currentPage, 10, query);
-      const data = res.data as PaginatedResponse<Group>;
-      setGroups(data.items);
-      setTotalPages(data.meta.totalPages);
-    } catch (err: any) {
-      setError(err.message);
-      setGroups([]);
-    }
-  };
+  }, [page, search, fetchGroups]);
 
   const openCreate = () => {
     setEditingId(null);

--- a/components/GroupSelect.tsx
+++ b/components/GroupSelect.tsx
@@ -29,8 +29,13 @@ export function GroupSelect({ value, onChange, label, placeholder }: GroupSelect
   const [newGroupName, setNewGroupName] = useState("");
 
   const loadGroups = async () => {
-    const res = await groupsApi.getAllGroups(1, 100);
-    setGroups(res.data.items || []);
+    try {
+      const res = await groupsApi.getAllGroups(1, 100);
+      setGroups(res.data?.items ?? []);
+    } catch (error) {
+      console.error("Failed to load groups", error);
+      setGroups([]);
+    }
   };
 
   useEffect(() => {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 
 interface User {
 	id: number;
@@ -10,41 +10,68 @@ interface User {
 }
 
 interface AuthState {
-	token: string | null;
-	user: User | null;
-	setToken: (token: string) => void;
-	setUser: (user: User) => void;
-	setRole: (role: string) => void;
-	logout: () => void;
+        token: string | null;
+        user: User | null;
+        hydrated: boolean;
+        setToken: (token: string) => void;
+        setUser: (user: User) => void;
+        setRole: (role: string) => void;
+        logout: () => void;
+        setHydrated: (value: boolean) => void;
 }
 
+const noopStorage: StateStorage = {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+};
+
 export const useAuthStore = create<AuthState>()(
-	persist(
-		(set) => ({
-			token: null, // Don't read from localStorage here
-			user: null,
-			setToken: (token) => {
-				if (typeof window !== "undefined") {
-					localStorage.setItem("token", token);
-				}
-				set({ token });
-			},
-			setUser: (user) => set({ user }),
-			setRole: (role) =>
-				set((state) => ({
-					user: state.user ? { ...state.user, role } : null,
-				})),
-			logout: () => {
-				if (typeof window !== "undefined") {
-					localStorage.removeItem("token");
-				}
-				set({ token: null, user: null });
-			},
-		}),
-		{
-			name: "auth-storage",
-			storage: createJSONStorage(() => localStorage),
-			skipHydration: true, // Add this line
-		}
-	)
+        persist(
+                (set) => ({
+                        token: null, // Don't read from localStorage here
+                        user: null,
+                        hydrated: false,
+                        setToken: (token) => {
+                                if (typeof window !== "undefined") {
+                                        localStorage.setItem("token", token);
+                                }
+                                set({ token, hydrated: true });
+                        },
+                        setUser: (user) => set({ user }),
+                        setRole: (role) =>
+                                set((state) => ({
+                                        user: state.user ? { ...state.user, role } : null,
+                                })),
+                        logout: () => {
+                                if (typeof window !== "undefined") {
+                                        localStorage.removeItem("token");
+                                }
+                                set({ token: null, user: null, hydrated: true });
+                        },
+                        setHydrated: (value) => set({ hydrated: value }),
+                }),
+                {
+                        name: "auth-storage",
+                        storage: createJSONStorage(() =>
+                                typeof window === "undefined" ? noopStorage : localStorage
+                        ),
+                        onRehydrateStorage: () => (state, error) => {
+                                if (error) {
+                                        if (typeof window !== "undefined") {
+                                                localStorage.removeItem("token");
+                                        }
+                                        state?.logout?.();
+                                        state?.setHydrated?.(true);
+                                        return;
+                                }
+
+                                state?.setHydrated?.(true);
+
+                                if (state?.token && typeof window !== "undefined") {
+                                        localStorage.setItem("token", state.token);
+                                }
+                        },
+                }
+        )
 );


### PR DESCRIPTION
## Summary
- normalize group API responses so UI components receive consistent items and pagination metadata even when the backend returns plain arrays
- update the persisted auth store to track hydration status and gate dashboard data loading/redirects until the state is ready
- harden group management flows (search pagination, Excel modal options) and add an ESLint config so linting runs non-interactively

## Testing
- npx eslint app/dashboard/admin/academic-groups/page.tsx app/dashboard/admin/group-management/page.tsx app/dashboard/admin/groups/page.tsx app/dashboard/admin/page.tsx app/dashboard/student/page.tsx app/dashboard/teacher/page.tsx components/GroupSelect.tsx lib/api.ts lib/store.ts --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68ca91398e60832491cd594e31fcb85d