### PR TITLE
Show full names in course and group listings

### DIFF
--- a/app/dashboard/admin/academic-groups/page.tsx
+++ b/app/dashboard/admin/academic-groups/page.tsx
@@ -90,20 +90,37 @@ export default function AcademicGroupsManagement() {
 	const [uploadedUsers, setUploadedUsers] = useState<
 		ExcelUploadResponse["users"]
 	>([]);
-	const [uploadErrors, setUploadErrors] = useState<string[]>([]);
-	const [duplicateUsers, setDuplicateUsers] = useState<
-		ExcelUploadResponse["duplicates"]
-	>([]);
-	const [isUploading, setIsUploading] = useState(false);
-	const [showUploadResults, setShowUploadResults] = useState(false);
+        const [uploadErrors, setUploadErrors] = useState<string[]>([]);
+        const [duplicateUsers, setDuplicateUsers] = useState<
+                ExcelUploadResponse["duplicates"]
+        >([]);
+        const [isUploading, setIsUploading] = useState(false);
+        const [showUploadResults, setShowUploadResults] = useState(false);
 
-	const [formData, setFormData] = useState({
-		groupName: "",
-		courseId: "",
-		professorId: "",
-		capacity: "30",
-		studentUsernames: "",
-	});
+        const [formData, setFormData] = useState({
+                groupName: "",
+                courseId: "",
+                professorId: "",
+                capacity: "30",
+                studentUsernames: "",
+        });
+
+        const formatUserName = (
+                user?: {
+                        firstName?: string | null;
+                        lastName?: string | null;
+                        username?: string | null;
+                } | null
+        ) => {
+                if (!user) return "نامشخص";
+                const parts = [user.firstName, user.lastName]
+                        .map((part) => part?.trim())
+                        .filter(Boolean) as string[];
+                if (parts.length > 0) {
+                        return parts.join(" ");
+                }
+                return user.username ?? "نامشخص";
+        };
 
 	const {
 		isOpen: isCreateGroupOpen,
@@ -680,23 +697,26 @@ export default function AcademicGroupsManagement() {
                                                                                                        />
 												</div>
 											}>
-											<TableHeader>
-												<TableColumn>نام کاربری</TableColumn>
-												<TableColumn>نام و نام خانوادگی</TableColumn>
-												<TableColumn>درس‌های ثبت‌نام شده</TableColumn>
-											</TableHeader>
+                                                                                        <TableHeader>
+                                                                                                <TableColumn>نام دانشجو</TableColumn>
+                                                                                                <TableColumn>درس‌های ثبت‌نام شده</TableColumn>
+                                                                                        </TableHeader>
 											<TableBody
 												loadingState={isLoading ? "loading" : "idle"}
 												emptyContent="دانشجویی یافت نشد">
 												{allStudents.map((student) => (
 													<TableRow key={student.id}>
-														<TableCell>{student.username}</TableCell>
-														<TableCell>
-															{student.firstName} {student.lastName}
-														</TableCell>
-														<TableCell>
-															<div className="flex gap-1 flex-wrap">
-																<Chip
+                                                                                                                <TableCell>
+                                                                                                                        <div className="flex flex-col">
+                                                                                                                                <span>{formatUserName(student)}</span>
+                                                                                                                                {student.username ? (
+                                                                                                                                        <span className="text-xs text-neutral-500">{student.username}</span>
+                                                                                                                                ) : null}
+                                                                                                                        </div>
+                                                                                                                </TableCell>
+                                                                                                                <TableCell>
+                                                                                                                        <div className="flex gap-1 flex-wrap">
+                                                                                                                               <Chip
 																	key={student.enrollmentId ?? student.id}
 																	size="sm"
 																	variant="flat"
@@ -891,11 +911,11 @@ export default function AcademicGroupsManagement() {
 									<TableCell>
 										{assignments
 											.filter((assignment) => assignment.groupId === group.id)
-											.map((assignment) => (
-												<div key={assignment.id}>
-													{assignment.professor.username}
-												</div>
-											))}
+                                                                                        .map((assignment) => (
+                                                                                                <div key={assignment.id}>
+                                                                                                        {formatUserName(assignment.professor)}
+                                                                                                </div>
+                                                                                        ))}
 									</TableCell>
 									<TableCell>
 										<Button
@@ -966,7 +986,7 @@ export default function AcademicGroupsManagement() {
 										{assignments.map((assignment) => (
 											<TableRow key={assignment.id}>
 												<TableCell>{assignment.course.name}</TableCell>
-												<TableCell>{assignment.professor.username}</TableCell>
+                                                                                            <TableCell>{formatUserName(assignment.professor)}</TableCell>
 												<TableCell>{assignment.capacity}</TableCell>
 												<TableCell>
 													<Button

--- a/app/dashboard/admin/course-groups/page.tsx
+++ b/app/dashboard/admin/course-groups/page.tsx
@@ -47,19 +47,27 @@ import {
 import { toast } from "sonner";
 
 interface CourseGroup {
-	id: number;
-	groupNumber: number;
-	currentEnrollment: number;
-	course: { id: number; name: string };
-	professor: { id: number; username: string; role: string };
+        id: number;
+        groupNumber: number;
+        currentEnrollment: number;
+        course: { id: number; name: string };
+        professor: {
+                id: number;
+                username: string;
+                role: string;
+                firstName?: string;
+                lastName?: string;
+        };
 }
 
 interface GroupStudentStatus {
-	id: number;
-	username: string;
-	isEnrolled: boolean;
-	canEnroll: boolean;
-	enrollmentStatus: "enrolled" | "can_enroll" | "cannot_enroll";
+        id: number;
+        username: string;
+        firstName?: string;
+        lastName?: string;
+        isEnrolled: boolean;
+        canEnroll: boolean;
+        enrollmentStatus: "enrolled" | "can_enroll" | "cannot_enroll";
 }
 
 interface GroupStatusResponse {
@@ -74,10 +82,10 @@ interface GroupStatusResponse {
 }
 
 interface RegisteredUser {
-	id: number;
-	username: string;
-	firstName: string;
-	lastName: string;
+        id: number;
+        username: string;
+        firstName: string;
+        lastName: string;
 }
 
 interface ApiErrorResponse {
@@ -106,12 +114,12 @@ interface BulkEnrollmentResponse {
 }
 
 interface GroupStudent {
-	id: number;
-	username: string;
-	firstName: string;
-	lastName: string;
-	isEnrolled: boolean;
-	canEnroll: boolean;
+        id: number;
+        username: string;
+        firstName: string;
+        lastName: string;
+        isEnrolled: boolean;
+        canEnroll: boolean;
 }
 
 interface GroupInfo {
@@ -128,8 +136,10 @@ interface Course {
 }
 
 interface Professor {
-	id: number;
-	username: string;
+        id: number;
+        username: string;
+        firstName?: string;
+        lastName?: string;
 }
 
 export default function CourseGroupsManagement() {
@@ -220,16 +230,22 @@ export default function CourseGroupsManagement() {
                 void fetchCoursesAndProfessors();
         }, [fetchCoursesAndProfessors]);
 
-	const fetchStudents = async () => {
-		try {
-			const { data } = await api.getUsers(1, 100, undefined, "student");
-			const usersData = data as PaginatedResponse;
-			setStudents(usersData.items);
-		} catch (err: any) {
-			setError(err.message);
-			setStudents([]);
-		}
-	};
+        const formatUserName = (
+                user?: {
+                        firstName?: string | null;
+                        lastName?: string | null;
+                        username?: string | null;
+                } | null
+        ) => {
+                if (!user) return "نامشخص";
+                const parts = [user.firstName, user.lastName]
+                        .map((part) => part?.trim())
+                        .filter(Boolean) as string[];
+                if (parts.length > 0) {
+                        return parts.join(" ");
+                }
+                return user.username ?? "نامشخص";
+        };
 
         const handleSearch = (value: string) => {
                 setSearchQuery(value);
@@ -515,9 +531,9 @@ export default function CourseGroupsManagement() {
 									</TableCell>
 									<TableCell>{group?.course?.name ?? "نامشخص"}</TableCell>
 									<TableCell>{group?.currentEnrollment}</TableCell>
-									<TableCell>
-										{group?.professor?.username ?? "نامشخص"}
-									</TableCell>
+                                                                        <TableCell>
+                                                                                {formatUserName(group?.professor)}
+                                                                        </TableCell>
 									<TableCell>
 										<Button
 											color="danger"
@@ -605,11 +621,11 @@ export default function CourseGroupsManagement() {
 									}
 									isLoading={isLoadingForm}>
 									{Array.isArray(professors)
-										? professors.map((prof) => (
-												<SelectItem key={prof.id} value={prof.id}>
-													{prof.username}
-												</SelectItem>
-										  ))
+                                                                                ? professors.map((prof) => (
+                                                                                                <SelectItem key={prof.id} value={prof.id}>
+                                                                                                        {formatUserName(prof)}
+                                                                                                </SelectItem>
+                                                                                  ))
 										: null}
 								</Select>
 							</ModalBody>
@@ -670,7 +686,7 @@ export default function CourseGroupsManagement() {
 												}}>
 												<TableHeader>
 													<TableColumn>انتخاب</TableColumn>
-													<TableColumn>نام کاربری</TableColumn>
+                                                                                                        <TableColumn>نام دانشجو</TableColumn>
 													<TableColumn>وضعیت</TableColumn>
 												</TableHeader>
 												<TableBody>
@@ -679,18 +695,20 @@ export default function CourseGroupsManagement() {
 															<TableCell>
                                                                                                                        <Checkbox
                                                                                                                                isSelected={selectedStudents.includes(
-                                                                                                                                       student.id
+                                                                                                                                        student.id
                                                                                                                                )}
                                                                                                                                onValueChange={() =>
-                                                                                                                                       handleStudentSelection(student.id)
+                                                                                                                                        handleStudentSelection(student.id)
                                                                                                                                }
                                                                                                                                isDisabled={
-                                                                                                                                       !student.canEnroll && !student.isEnrolled
+                                                                                                                                        !student.canEnroll && !student.isEnrolled
                                                                                                                                }
-                                                                                                                               aria-label={`انتخاب ${student.username}`}
+                                                                                                                               aria-label={`انتخاب ${formatUserName(student)}`}
                                                                                                                        />
-															</TableCell>
-															<TableCell>{student.username}</TableCell>
+                                                                                                                       </TableCell>
+                                                                                                                        <TableCell>
+                                                                                                                                {formatUserName(student)}
+                                                                                                                        </TableCell>
 															<TableCell>
 																{student.isEnrolled ? (
 																	<Chip

--- a/app/dashboard/student/page.tsx
+++ b/app/dashboard/student/page.tsx
@@ -80,14 +80,13 @@ interface CourseEnrollment {
 }
 
 interface FlattenedCourseData {
-	courseId: number;
-	courseName: string;
-	courseCode: string;
-	groupNumber: number;
-	groupId: number;
-	isActive: boolean;
-	enrollmentId: number;
-	score: number | null;
+        courseId: number;
+        courseName: string;
+        groupNumber: number;
+        groupId: number;
+        isActive: boolean;
+        enrollmentId: number;
+        score: number | null;
 }
 
 interface Objection {
@@ -205,13 +204,12 @@ export default function StudentDashboard() {
 	): FlattenedCourseData[] => {
 		return courses.flatMap((course) =>
 			course.groups.flatMap((group) =>
-				group.enrollments.map((enrollment) => ({
-					courseId: course.id,
-					courseName: course.name,
-					courseCode: course.code,
-					groupNumber: group.groupNumber,
-					groupId: group.id,
-					isActive: group.isActive,
+                                group.enrollments.map((enrollment) => ({
+                                        courseId: course.id,
+                                        courseName: course.name,
+                                        groupNumber: group.groupNumber,
+                                        groupId: group.id,
+                                        isActive: group.isActive,
 					enrollmentId: enrollment.id,
 					score: enrollment.score,
 				}))
@@ -281,24 +279,18 @@ export default function StudentDashboard() {
 					</div>
 
 					<Table removeWrapper aria-label="Course list">
-						<TableHeader>
-							<TableColumn>نام درس</TableColumn>
-							<TableColumn>کد درس</TableColumn>
-							<TableColumn>گروه</TableColumn>
-							<TableColumn>نمره</TableColumn>
-							<TableColumn>عملیات</TableColumn>
+                                        <TableHeader>
+                                                <TableColumn>نام درس</TableColumn>
+                                                <TableColumn>گروه</TableColumn>
+                                                <TableColumn>نمره</TableColumn>
+                                                <TableColumn>عملیات</TableColumn>
 						</TableHeader>
 						<TableBody emptyContent="هیچ درسی یافت نشد">
 							{flattenCourseData(courses).map((item) => (
 								<TableRow key={item.enrollmentId}>
-									<TableCell className="font-medium">
-										{item.courseName}
-									</TableCell>
-									<TableCell>
-										<Chip size="sm" variant="flat">
-											{item.courseCode}
-										</Chip>
-									</TableCell>
+                                                                        <TableCell className="font-medium">
+                                                                                {item.courseName}
+                                                                        </TableCell>
 									<TableCell>
 										<Chip
 											variant="dot"

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -174,19 +174,21 @@ interface Course {
 }
 
 interface GroupResponse {
-	id: number;
-	groupNumber: number;
-	currentEnrollment: number;
-	capacity: number;
-	course: {
-		id: number;
-		name: string;
-	};
-	professor: {
-		id: number;
-		username: string;
-		role: string; // Add role property
-	};
+        id: number;
+        groupNumber: number;
+        currentEnrollment: number;
+        capacity: number;
+        course: {
+                id: number;
+                name: string;
+        };
+        professor: {
+                id: number;
+                username: string;
+                firstName?: string;
+                lastName?: string;
+                role: string; // Add role property
+        };
 }
 
 interface GroupStudentStatus {
@@ -232,6 +234,8 @@ export const courseGroupsApi = {
                         students: Array<{
                                 id: number;
                                 username: string;
+                                firstName?: string;
+                                lastName?: string;
                                 isEnrolled: boolean;
                                 canEnroll: boolean;
                         }>;

--- a/lib/types/common.ts
+++ b/lib/types/common.ts
@@ -39,40 +39,46 @@ export interface Course {
 }
 
 export interface CourseAssignment {
-	id: number;
-	groupId: number;
-	courseId: number;
-	professorId: number;
-	capacity: number;
-	currentEnrollment: number;
-	course: Course;
-	professor: {
-		id: number;
-		username: string;
-		role: string;
-	};
+        id: number;
+        groupId: number;
+        courseId: number;
+        professorId: number;
+        capacity: number;
+        currentEnrollment: number;
+        course: Course;
+        professor: {
+                id: number;
+                username: string;
+                role: string;
+                firstName?: string;
+                lastName?: string;
+        };
 }
 
 export interface Enrollment {
-	id: number;
-	student: {
-		id: number;
-		username: string;
-	};
-	group: {
-		id: number;
+        id: number;
+        student: {
+                id: number;
+                username: string;
+                firstName?: string;
+                lastName?: string;
+        };
+        group: {
+                id: number;
                 groupNumber: number;
                 course: {
                         id: number;
                         name: string;
                         code: string;
                 };
-		professor: {
-			id: number;
-			username: string;
-		};
-	};
-	score: number | null;
+                professor: {
+                        id: number;
+                        username: string;
+                        firstName?: string;
+                        lastName?: string;
+                };
+        };
+        score: number | null;
 	createdAt: Date;
 	isActive: boolean;
 }


### PR DESCRIPTION
## Summary
- remove the course code column from the student dashboard course table
- display professors and students by full name in course and academic group management screens
- extend shared API/type definitions to include optional first and last name fields for group-related entities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cae9f1d4b48324b9268c33de808c2b